### PR TITLE
Upgrade deprecated runtime nodejs6.10

### DIFF
--- a/lambda_file_processing.template
+++ b/lambda_file_processing.template
@@ -115,7 +115,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs6.10",
+        "Runtime": "nodejs10.x",
         "MemorySize": 128,
         "Timeout": 3
       }
@@ -135,7 +135,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs6.10",
+        "Runtime": "nodejs10.x",
         "MemorySize": 128,
         "Timeout": 3
       }

--- a/lambda_file_processing.yml
+++ b/lambda_file_processing.yml
@@ -6,7 +6,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: data-processor-1.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       CodeUri: ./src/data-processor-1/
       Role: !GetAtt [LambdaExecutionRole, Arn]
       
@@ -14,7 +14,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: data-processor-2.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       CodeUri: ./src/data-processor-2/
       Role: !GetAtt [LambdaExecutionRole, Arn]
 


### PR DESCRIPTION
CloudFormation templates in lambda-refarch-fileprocessing have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs6.10). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.